### PR TITLE
Feature: add more scale options

### DIFF
--- a/client/app/page.test.tsx
+++ b/client/app/page.test.tsx
@@ -21,7 +21,7 @@ describe('Home Page', () => {
 
 	it('renders the full keyboard', () => {
 		const keyboardFull = screen.getByRole('group', {
-			name: 'Full keyboard keys',
+			name: /Full keyboard keys/i,
 		});
 
 		expect(keyboardFull).toBeInTheDocument();
@@ -29,7 +29,7 @@ describe('Home Page', () => {
 
 	it('renders the selected keyboard', () => {
 		const keyboardSelected = screen.getByRole('region', {
-			name: 'Selected Keyboard: audio controls and keys',
+			name: /Selected Keyboard: audio controls and keys/i,
 		});
 
 		expect(keyboardSelected).toBeInTheDocument();

--- a/client/components/audio-controls/audio-controls.test.tsx
+++ b/client/components/audio-controls/audio-controls.test.tsx
@@ -24,14 +24,14 @@ describe('Audio Controls', () => {
 
 	it('renders the audio controls div', () => {
 		const audioControls = screen.getByRole('group', {
-			name: 'Audio controls',
+			name: /Audio controls/i,
 		});
 
 		expect(audioControls).toBeInTheDocument();
 	});
 
 	it('renders the play button', () => {
-		const button = screen.getByRole('button', { name: 'Play the scale' });
+		const button = screen.getByRole('button', { name: /Play the scale/i });
 
 		expect(button).toBeInTheDocument();
 	});
@@ -39,7 +39,7 @@ describe('Audio Controls', () => {
 	it('handles the play click', async () => {
 		vi.useFakeTimers();
 
-		const button = screen.getByRole('button', { name: 'Play the scale' });
+		const button = screen.getByRole('button', { name: /Play the scale/i });
 		const mockNumberOfNotes = 13; // length of chromatic scale
 
 		await act(async () => {

--- a/client/components/common/custom-button/custom-button.test.tsx
+++ b/client/components/common/custom-button/custom-button.test.tsx
@@ -16,14 +16,14 @@ describe('Custom Button', () => {
 	});
 
 	it('renders the button with children', () => {
-		const button = screen.getByRole('button', { name: 'Test the Button' });
+		const button = screen.getByRole('button', { name: /Test the Button/i });
 
 		expect(button).toBeInTheDocument();
 		expect(screen.getByText('Test Button')).toBeInTheDocument();
 	});
 
 	it('calls onClick when clicked', () => {
-		const button = screen.getByRole('button', { name: 'Test the Button' });
+		const button = screen.getByRole('button', { name: /Test the Button/i });
 
 		fireEvent.click(button);
 

--- a/client/components/common/dropdown/dropdown.test.tsx
+++ b/client/components/common/dropdown/dropdown.test.tsx
@@ -23,7 +23,7 @@ describe('Dropdown', () => {
 
 	it('renders the dropdown with all options', () => {
 		const dropdown = screen.getByRole('combobox', {
-			name: 'Select an option',
+			name: /Select an option/i,
 		});
 
 		expect(dropdown).toBeInTheDocument();
@@ -34,18 +34,18 @@ describe('Dropdown', () => {
 
 	it('renders the label for the dropdown', () => {
 		const dropdown = screen.getByRole('combobox', {
-			name: 'Select an option',
+			name: /Select an option/i,
 		});
 		const label = screen.getByText('Test dropdown');
 
 		expect(dropdown).toBeInTheDocument();
 		expect(label).toBeInTheDocument();
-		expect(label).toHaveTextContent('Test dropdown');
+		expect(label).toHaveTextContent(/Test dropdown/i);
 	});
 
 	it('displays the selected value correctly', () => {
 		const dropdown = screen.getByRole('combobox', {
-			name: 'Select an option',
+			name: /Select an option/i,
 		});
 
 		expect(dropdown).toHaveValue('b');
@@ -64,7 +64,7 @@ describe('Dropdown', () => {
 			/>
 		);
 		const dropdown = screen.getByRole('combobox', {
-			name: 'Select an option',
+			name: /Select an option/i,
 		});
 
 		fireEvent.change(dropdown, { target: { value: 'c' } });

--- a/client/components/common/scrollbar/scrollbar.test.tsx
+++ b/client/components/common/scrollbar/scrollbar.test.tsx
@@ -14,7 +14,7 @@ describe('Scrollbar', () => {
 
 	it('renders correctly with children', () => {
 		const scrollbar = screen.getByRole('scrollbar', {
-			name: 'Scrollable area',
+			name: /Scrollable area/i,
 		});
 		const childElement = screen.getByText('Test Child');
 
@@ -24,7 +24,7 @@ describe('Scrollbar', () => {
 
 	it('has the correct aria attributes', () => {
 		const scrollbar = screen.getByRole('scrollbar', {
-			name: 'Scrollable area',
+			name: /Scrollable area/i,
 		});
 
 		expect(scrollbar).toHaveAttribute('aria-controls', 'scrollable-content');
@@ -33,7 +33,7 @@ describe('Scrollbar', () => {
 
 	it('is focusable', () => {
 		const scrollbar = screen.getByRole('scrollbar', {
-			name: 'Scrollable area',
+			name: /Scrollable area/i,
 		});
 
 		scrollbar.focus();

--- a/client/components/key/index.tsx
+++ b/client/components/key/index.tsx
@@ -2,7 +2,8 @@
 // Each key within the keyboard. Contains click actions to play and highlight a specific note.
 // The note prop will determine the keys style, label, and the sound played.
 // From the context, selectedWaveform will also help determine the sound played.
-// If the activeNote matches the key's note, the key will be highlighted.
+// If the activeNote matches the key's note, the key will be appear 'active.
+// If they key's note is included in the selected scale, it will appear highlighted.
 
 'use client';
 

--- a/client/components/key/key.test.tsx
+++ b/client/components/key/key.test.tsx
@@ -22,7 +22,7 @@ describe('Key', () => {
 				<Key note={mockNote} isSelectedKeyboard />
 			</KeyboardOptionsProvider>
 		);
-		button = screen.getByRole('button', { name: 'Play the D♭4 note' });
+		button = screen.getByRole('button', { name: /Play the D♭4 note/i });
 	});
 
 	afterEach(() => {

--- a/client/components/keyboard-full/keyboard-full.test.tsx
+++ b/client/components/keyboard-full/keyboard-full.test.tsx
@@ -15,7 +15,7 @@ describe('Full Keyboard', () => {
 
 	it('renders the full keyboard div', () => {
 		const fullKeyboard = screen.getByRole('group', {
-			name: 'Full keyboard keys',
+			name: /Full keyboard keys/i,
 		});
 
 		expect(fullKeyboard).toBeInTheDocument();
@@ -23,7 +23,7 @@ describe('Full Keyboard', () => {
 
 	it('renders 7 octaves', () => {
 		const fullKeyboard = screen.getByRole('group', {
-			name: 'Full keyboard keys',
+			name: /Full keyboard keys/i,
 		});
 
 		expect(fullKeyboard.children.length).toBe(7);
@@ -31,7 +31,7 @@ describe('Full Keyboard', () => {
 
 	it('renders a scrollbar', () => {
 		const scrollbar = screen.getByRole('scrollbar', {
-			name: 'Scrollable area',
+			name: /Scrollable area/i,
 		});
 
 		expect(scrollbar).toBeInTheDocument();

--- a/client/components/keyboard-selected/keyboard-selected.test.tsx
+++ b/client/components/keyboard-selected/keyboard-selected.test.tsx
@@ -15,7 +15,7 @@ describe('Selected Keyboard', () => {
 
 	it('renders the selected keyboard', () => {
 		const keyboardSelected = screen.getByRole('region', {
-			name: 'Selected Keyboard: audio controls and keys',
+			name: /Selected Keyboard: audio controls and keys/i,
 		});
 
 		expect(keyboardSelected).toBeInTheDocument();
@@ -23,7 +23,7 @@ describe('Selected Keyboard', () => {
 
 	it('renders the audio controls div', () => {
 		const audioControls = screen.getByRole('group', {
-			name: 'Audio controls',
+			name: /Audio controls/i,
 		});
 
 		expect(audioControls).toBeInTheDocument();
@@ -31,7 +31,7 @@ describe('Selected Keyboard', () => {
 
 	it('renders the default octave with the correct selection of keys', () => {
 		const octave = screen.getByRole('group', {
-			name: 'Octave for C4',
+			name: /Octave for C4/i,
 		});
 
 		expect(octave).toBeInTheDocument();

--- a/client/components/keyboard-settings/keyboard-settings.test.tsx
+++ b/client/components/keyboard-settings/keyboard-settings.test.tsx
@@ -15,14 +15,14 @@ describe('Keyboard settings', () => {
 
 	it('renders the keyboard settings group', () => {
 		const keyboardSettings = screen.getByRole('group', {
-			name: 'Keyboard settings',
+			name: /Keyboard settings/i,
 		});
 
 		expect(keyboardSettings).toBeInTheDocument();
 	});
 
 	it('renders the key dropdown and options', () => {
-		const dropdown = screen.getByRole('combobox', { name: 'Select a key' });
+		const dropdown = screen.getByRole('combobox', { name: /Select a key/i });
 
 		expect(dropdown).toBeInTheDocument();
 		expect(dropdown).toHaveTextContent('C');
@@ -31,7 +31,9 @@ describe('Keyboard settings', () => {
 	});
 
 	it('renders the octave dropdown and options', () => {
-		const dropdown = screen.getByRole('combobox', { name: 'Select an octave' });
+		const dropdown = screen.getByRole('combobox', {
+			name: /Select an octave/i,
+		});
 
 		expect(dropdown).toBeInTheDocument();
 		expect(dropdown).toHaveTextContent('1');
@@ -41,7 +43,7 @@ describe('Keyboard settings', () => {
 
 	it('renders the waveform dropdown and options', () => {
 		const dropdown = screen.getByRole('combobox', {
-			name: 'Select a waveform',
+			name: /Select a waveform/i,
 		});
 
 		expect(dropdown).toBeInTheDocument();
@@ -52,7 +54,7 @@ describe('Keyboard settings', () => {
 
 	it('renders the scale dropdown and options', () => {
 		const dropdown = screen.getByRole('combobox', {
-			name: 'Select a scale',
+			name: /Select a scale/i,
 		});
 
 		expect(dropdown).toBeInTheDocument();

--- a/client/components/layout/header/header.test.tsx
+++ b/client/components/layout/header/header.test.tsx
@@ -30,7 +30,7 @@ describe('Header', () => {
 
 	it('renders the settings button', () => {
 		const button = screen.getByRole('button', {
-			name: 'Open keyboard settings',
+			name: /Open keyboard settings/i,
 		});
 
 		expect(button).toBeInTheDocument();
@@ -38,13 +38,13 @@ describe('Header', () => {
 
 	it('toggles the settings after clicking settings button', () => {
 		const button = screen.getByRole('button', {
-			name: 'Open keyboard settings',
+			name: /Open keyboard settings/i,
 		});
 
 		fireEvent.click(button);
 
 		const keyboardSettings = screen.getByRole('group', {
-			name: 'Keyboard settings',
+			name: /Keyboard settings/i,
 		});
 
 		expect(keyboardSettings).toBeInTheDocument();

--- a/client/components/octave/octave.test.tsx
+++ b/client/components/octave/octave.test.tsx
@@ -31,7 +31,7 @@ describe('Octave', () => {
 
 	it('renders the octave div', () => {
 		const octave = screen.getByRole('group', {
-			name: 'Octave for C4',
+			name: /Octave for C4/i,
 		});
 
 		expect(octave).toBeInTheDocument();
@@ -39,7 +39,7 @@ describe('Octave', () => {
 
 	it('renders each note as a child', () => {
 		const octave = screen.getByRole('group', {
-			name: 'Octave for C4',
+			name: /Octave for C4/i,
 		});
 
 		expect(octave.children.length).toBe(12);

--- a/client/context/keyboard-options-context.test.tsx
+++ b/client/context/keyboard-options-context.test.tsx
@@ -1,10 +1,32 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import type { ChangeEvent } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 
 import {
 	KeyboardOptionsProvider,
 	useKeyboardOptions,
 } from './keyboard-options-context';
+
+interface selectInputProps {
+	label: string;
+	value: string | number;
+	options: string[] | number[];
+	onChange: (e: ChangeEvent<HTMLSelectElement>) => void;
+}
+
+const SelectInput = ({ label, value, options, onChange }: selectInputProps) => (
+	<div>
+		<label htmlFor={label}>Select {label}:</label>
+		<select id={label} name={label} value={value} onChange={onChange}>
+			{options.map((option) => (
+				<option key={option} value={option}>
+					{option}
+				</option>
+			))}
+		</select>
+		<p>{`Selected ${label}: ${value}`}</p>
+	</div>
+);
 
 const TestComponent = () => {
 	const {
@@ -23,71 +45,42 @@ const TestComponent = () => {
 
 	return (
 		<div>
-			<div>
-				<label htmlFor="key-select">Select Key:</label>
-				<select
-					id="key-select"
-					name="key"
-					value={selectedKey}
-					onChange={onKeyChange}
-				>
-					<option value="C">C</option>
-					<option value="D">D</option>
-					<option value="E">E</option>
-				</select>
-				<p>Selected Key: {selectedKey}</p>
-			</div>
+			<SelectInput
+				label="key"
+				value={selectedKey}
+				options={['C', 'D', 'E']}
+				onChange={onKeyChange}
+			/>
 
-			<div>
-				<label htmlFor="octave-select">Select Octave:</label>
-				<select
-					id="octave-select"
-					name="octave"
-					value={selectedOctave}
-					onChange={onOctaveChange}
-				>
-					<option value={3}>3</option>
-					<option value={4}>4</option>
-					<option value={5}>5</option>
-				</select>
-				<p>Selected Octave: {selectedOctave}</p>
-			</div>
+			<SelectInput
+				label="octave"
+				value={selectedOctave}
+				options={[3, 4, 5]}
+				onChange={onOctaveChange}
+			/>
 
-			<div>
-				<label htmlFor="waveform-select">Select Waveform:</label>
-				<select
-					id="waveform-select"
-					name="waveform"
-					value={selectedWaveform}
-					onChange={onWaveformChange}
-				>
-					<option value="sine">Sine</option>
-					<option value="square">Square</option>
-					<option value="triangle">Triangle</option>
-					<option value="sawtooth">Sawtooth</option>
-				</select>
-				<p>Selected Waveform: {selectedWaveform}</p>
-			</div>
+			<SelectInput
+				label="waveform"
+				value={selectedWaveform}
+				options={['sine', 'square', 'triangle', 'sawtooth']}
+				onChange={onWaveformChange}
+			/>
 
-			<div>
-				<label htmlFor="scale-select">Select Scale:</label>
-				<select
-					id="scale-select"
-					name="scale"
-					value={selectedScale}
-					onChange={onScaleChange}
-				>
-					<option value="chromatic">Chromatic</option>
-					<option value="major">Major</option>
-					<option value="natural minor">Natural Minor</option>
-					<option value="harmonic minor">Harmonic Minor</option>
-					<option value="melodic minor">Melodic Minor</option>
-					<option value="major pentatonic">Major Pentatonic</option>
-					<option value="minor pentatonic">Minor Pentatonic</option>
-					<option value="blues">Blues</option>
-				</select>
-				<p>Selected Scale: {selectedScale}</p>
-			</div>
+			<SelectInput
+				label="scale"
+				value={selectedScale}
+				options={[
+					'chromatic',
+					'major',
+					'natural minor',
+					'harmonic minor',
+					'melodic minor',
+					'major pentatonic',
+					'minor pentatonic',
+					'blues',
+				]}
+				onChange={onScaleChange}
+			/>
 
 			<div>
 				<p>Active Note: {activeNote || 'None'}</p>
@@ -99,9 +92,8 @@ const TestComponent = () => {
 				</button>
 				<button onClick={() => setActiveNote(null)}>Clear Active Note</button>
 			</div>
-
 			<div>
-				<p>Selected Scale Notes: {selectedScaleNotes.join('-')}</p>
+				<p>Selected scale notes: {selectedScaleNotes.join('-')}</p>
 			</div>
 		</div>
 	);
@@ -124,43 +116,43 @@ describe('KeyboardOptionsProvider', () => {
 	it('provides the initial values', () => {
 		renderWithProvider();
 
-		expect(screen.getByText('Selected Key: C')).toBeInTheDocument();
-		expect(screen.getByText('Selected Octave: 4')).toBeInTheDocument();
-		expect(screen.getByText('Selected Waveform: sine')).toBeInTheDocument();
-		expect(screen.getByText('Selected Scale: chromatic')).toBeInTheDocument();
-		expect(screen.getByText('Active Note: None')).toBeInTheDocument();
+		expect(screen.getByText(/Selected key: C/i)).toBeInTheDocument();
+		expect(screen.getByText(/Selected octave: 4/i)).toBeInTheDocument();
+		expect(screen.getByText(/Selected waveform: sine/i)).toBeInTheDocument();
+		expect(screen.getByText(/Selected scale: chromatic/i)).toBeInTheDocument();
+		expect(screen.getByText(/Active note: None/i)).toBeInTheDocument();
 	});
 
 	it('updates the selected key on change event', () => {
 		renderWithProvider();
 
-		changeSelection('Select Key:', 'D');
+		changeSelection('Select key:', 'D');
 
-		expect(screen.getByText('Selected Key: D')).toBeInTheDocument();
+		expect(screen.getByText(/Selected key: D/i)).toBeInTheDocument();
 	});
 
 	it('updates the selected octave on change event', () => {
 		renderWithProvider();
 
-		changeSelection('Select Octave:', '5');
+		changeSelection('Select octave:', '5');
 
-		expect(screen.getByText('Selected Octave: 5')).toBeInTheDocument();
+		expect(screen.getByText(/Selected octave: 5/i)).toBeInTheDocument();
 	});
 
 	it('updates the selected waveform on change event', () => {
 		renderWithProvider();
 
-		changeSelection('Select Waveform:', 'square');
+		changeSelection('Select waveform:', 'square');
 
-		expect(screen.getByText('Selected Waveform: square')).toBeInTheDocument();
+		expect(screen.getByText(/Selected waveform: square/i)).toBeInTheDocument();
 	});
 
 	it('updates the selected scale on change event', () => {
 		renderWithProvider();
 
-		changeSelection('Select Scale:', 'major');
+		changeSelection('Select scale:', 'major');
 
-		expect(screen.getByText('Selected Scale: major')).toBeInTheDocument();
+		expect(screen.getByText(/Selected scale: major/i)).toBeInTheDocument();
 	});
 
 	it('updates the active note when setActiveNote is called', () => {
@@ -169,22 +161,22 @@ describe('KeyboardOptionsProvider', () => {
 		fireEvent.click(
 			screen.getByRole('button', { name: /set active note to C4/i })
 		);
-		expect(screen.getByText('Active Note: C4')).toBeInTheDocument();
+		expect(screen.getByText(/Active Note: C4/i)).toBeInTheDocument();
 
 		fireEvent.click(
 			screen.getByRole('button', { name: /set active note to D4/i })
 		);
-		expect(screen.getByText('Active Note: D4')).toBeInTheDocument();
+		expect(screen.getByText(/Active Note: D4/i)).toBeInTheDocument();
 
 		fireEvent.click(screen.getByText('Clear Active Note'));
-		expect(screen.getByText('Active Note: None')).toBeInTheDocument();
+		expect(screen.getByText(/Active Note: None/i)).toBeInTheDocument();
 	});
 
 	it('defines the correct set of selected notes based on octave and key', () => {
 		renderWithProvider();
 
-		changeSelection('Select Key:', 'D');
-		changeSelection('Select Octave:', '5');
+		changeSelection('Select key:', 'D');
+		changeSelection('Select octave:', '5');
 
 		const scaleTests = [
 			{
@@ -201,9 +193,9 @@ describe('KeyboardOptionsProvider', () => {
 		];
 
 		scaleTests.forEach(({ scale, expected }) => {
-			changeSelection('Select Scale:', scale);
+			changeSelection('Select scale:', scale);
 			expect(
-				screen.getByText(`Selected Scale Notes: ${expected}`)
+				screen.getByText(`Selected scale notes: ${expected}`)
 			).toBeInTheDocument();
 		});
 	});

--- a/client/context/keyboard-options-context.test.tsx
+++ b/client/context/keyboard-options-context.test.tsx
@@ -79,6 +79,12 @@ const TestComponent = () => {
 				>
 					<option value="chromatic">Chromatic</option>
 					<option value="major">Major</option>
+					<option value="natural minor">Natural Minor</option>
+					<option value="harmonic minor">Harmonic Minor</option>
+					<option value="melodic minor">Melodic Minor</option>
+					<option value="major pentatonic">Major Pentatonic</option>
+					<option value="minor pentatonic">Minor Pentatonic</option>
+					<option value="blues">Blues</option>
 				</select>
 				<p>Selected Scale: {selectedScale}</p>
 			</div>
@@ -179,10 +185,46 @@ describe('KeyboardOptionsProvider', () => {
 
 		changeSelection('Select Key:', 'D');
 		changeSelection('Select Octave:', '5');
-		changeSelection('Select Scale:', 'major');
 
 		expect(
+			screen.getByText(
+				'Selected Scale Notes: D5-E♭5-E5-F5-G♭5-G5-A♭5-A5-B♭5-B5-C6-D♭6-D6'
+			)
+		).toBeInTheDocument();
+
+		changeSelection('Select Scale:', 'major');
+		expect(
 			screen.getByText('Selected Scale Notes: D5-E5-G♭5-G5-A5-B5-D♭6-D6')
+		).toBeInTheDocument();
+
+		changeSelection('Select Scale:', 'natural minor');
+		expect(
+			screen.getByText('Selected Scale Notes: D5-E5-F5-G5-A5-B♭5-C6-D6')
+		).toBeInTheDocument();
+
+		changeSelection('Select Scale:', 'harmonic minor');
+		expect(
+			screen.getByText('Selected Scale Notes: D5-E5-F5-G5-A5-B♭5-D♭6-D6')
+		).toBeInTheDocument();
+
+		changeSelection('Select Scale:', 'melodic minor');
+		expect(
+			screen.getByText('Selected Scale Notes: D5-E5-F5-G5-A5-B5-D♭6-D6')
+		).toBeInTheDocument();
+
+		changeSelection('Select Scale:', 'major pentatonic');
+		expect(
+			screen.getByText('Selected Scale Notes: D5-E5-G♭5-A5-B5-D6')
+		).toBeInTheDocument();
+
+		changeSelection('Select Scale:', 'minor pentatonic');
+		expect(
+			screen.getByText('Selected Scale Notes: D5-F5-G5-A5-C6-D6')
+		).toBeInTheDocument();
+
+		changeSelection('Select Scale:', 'blues');
+		expect(
+			screen.getByText('Selected Scale Notes: D5-F5-G5-A♭5-A5-C6-D6')
 		).toBeInTheDocument();
 	});
 

--- a/client/context/keyboard-options-context.test.tsx
+++ b/client/context/keyboard-options-context.test.tsx
@@ -180,52 +180,32 @@ describe('KeyboardOptionsProvider', () => {
 		expect(screen.getByText('Active Note: None')).toBeInTheDocument();
 	});
 
-	it('returns the correct set of selected notes based on octave and key', () => {
+	it('defines the correct set of selected notes based on octave and key', () => {
 		renderWithProvider();
 
 		changeSelection('Select Key:', 'D');
 		changeSelection('Select Octave:', '5');
 
-		expect(
-			screen.getByText(
-				'Selected Scale Notes: D5-E♭5-E5-F5-G♭5-G5-A♭5-A5-B♭5-B5-C6-D♭6-D6'
-			)
-		).toBeInTheDocument();
+		const scaleTests = [
+			{
+				scale: 'chromatic',
+				expected: 'D5-E♭5-E5-F5-G♭5-G5-A♭5-A5-B♭5-B5-C6-D♭6-D6',
+			},
+			{ scale: 'major', expected: 'D5-E5-G♭5-G5-A5-B5-D♭6-D6' },
+			{ scale: 'natural minor', expected: 'D5-E5-F5-G5-A5-B♭5-C6-D6' },
+			{ scale: 'harmonic minor', expected: 'D5-E5-F5-G5-A5-B♭5-D♭6-D6' },
+			{ scale: 'melodic minor', expected: 'D5-E5-F5-G5-A5-B5-D♭6-D6' },
+			{ scale: 'major pentatonic', expected: 'D5-E5-G♭5-A5-B5-D6' },
+			{ scale: 'minor pentatonic', expected: 'D5-F5-G5-A5-C6-D6' },
+			{ scale: 'blues', expected: 'D5-F5-G5-A♭5-A5-C6-D6' },
+		];
 
-		changeSelection('Select Scale:', 'major');
-		expect(
-			screen.getByText('Selected Scale Notes: D5-E5-G♭5-G5-A5-B5-D♭6-D6')
-		).toBeInTheDocument();
-
-		changeSelection('Select Scale:', 'natural minor');
-		expect(
-			screen.getByText('Selected Scale Notes: D5-E5-F5-G5-A5-B♭5-C6-D6')
-		).toBeInTheDocument();
-
-		changeSelection('Select Scale:', 'harmonic minor');
-		expect(
-			screen.getByText('Selected Scale Notes: D5-E5-F5-G5-A5-B♭5-D♭6-D6')
-		).toBeInTheDocument();
-
-		changeSelection('Select Scale:', 'melodic minor');
-		expect(
-			screen.getByText('Selected Scale Notes: D5-E5-F5-G5-A5-B5-D♭6-D6')
-		).toBeInTheDocument();
-
-		changeSelection('Select Scale:', 'major pentatonic');
-		expect(
-			screen.getByText('Selected Scale Notes: D5-E5-G♭5-A5-B5-D6')
-		).toBeInTheDocument();
-
-		changeSelection('Select Scale:', 'minor pentatonic');
-		expect(
-			screen.getByText('Selected Scale Notes: D5-F5-G5-A5-C6-D6')
-		).toBeInTheDocument();
-
-		changeSelection('Select Scale:', 'blues');
-		expect(
-			screen.getByText('Selected Scale Notes: D5-F5-G5-A♭5-A5-C6-D6')
-		).toBeInTheDocument();
+		scaleTests.forEach(({ scale, expected }) => {
+			changeSelection('Select Scale:', scale);
+			expect(
+				screen.getByText(`Selected Scale Notes: ${expected}`)
+			).toBeInTheDocument();
+		});
 	});
 
 	it('throws an error when used outside of the provider', () => {

--- a/client/context/keyboard-options-context.test.tsx
+++ b/client/context/keyboard-options-context.test.tsx
@@ -7,14 +7,14 @@ import {
 	useKeyboardOptions,
 } from './keyboard-options-context';
 
-interface selectInputProps {
+interface SelectInputProps {
 	label: string;
 	value: string | number;
 	options: string[] | number[];
 	onChange: (e: ChangeEvent<HTMLSelectElement>) => void;
 }
 
-const SelectInput = ({ label, value, options, onChange }: selectInputProps) => (
+const SelectInput = ({ label, value, options, onChange }: SelectInputProps) => (
 	<div>
 		<label htmlFor={label}>Select {label}:</label>
 		<select id={label} name={label} value={value} onChange={onChange}>

--- a/client/context/keyboard-options-context.tsx
+++ b/client/context/keyboard-options-context.tsx
@@ -93,11 +93,30 @@ export const KeyboardOptionsProvider = ({
 	const fullNotesOctave = rearrangeNotes();
 
 	function defineScaleNotes(fullNotesOctave: FullNote[]): FullNote[] {
+		let indexesToSelect: number[];
+
 		switch (selectedScale) {
 			case 'major':
-				const indexesToSelect = [0, 2, 4, 5, 7, 9, 11, 12];
+				indexesToSelect = [0, 2, 4, 5, 7, 9, 11, 12];
 				return indexesToSelect.map((index) => fullNotesOctave[index]);
-
+			case 'natural minor':
+				indexesToSelect = [0, 2, 3, 5, 7, 8, 10, 12];
+				return indexesToSelect.map((index) => fullNotesOctave[index]);
+			case 'harmonic minor':
+				indexesToSelect = [0, 2, 3, 5, 7, 8, 11, 12];
+				return indexesToSelect.map((index) => fullNotesOctave[index]);
+			case 'melodic minor':
+				indexesToSelect = [0, 2, 3, 5, 7, 9, 11, 12];
+				return indexesToSelect.map((index) => fullNotesOctave[index]);
+			case 'major pentatonic':
+				indexesToSelect = [0, 2, 4, 7, 9, 12];
+				return indexesToSelect.map((index) => fullNotesOctave[index]);
+			case 'minor pentatonic':
+				indexesToSelect = [0, 3, 5, 7, 10, 12];
+				return indexesToSelect.map((index) => fullNotesOctave[index]);
+			case 'blues':
+				indexesToSelect = [0, 3, 5, 6, 7, 10, 12];
+				return indexesToSelect.map((index) => fullNotesOctave[index]);
 			default:
 				// chromatic
 				return fullNotesOctave;

--- a/client/context/keyboard-options-context.tsx
+++ b/client/context/keyboard-options-context.tsx
@@ -95,6 +95,8 @@ export const KeyboardOptionsProvider = ({
 	function defineScaleNotes(fullNotesOctave: FullNote[]): FullNote[] {
 		let indexesToSelect: number[];
 
+		// using the selectedScale, follow the provided array pattern to
+		// return only the notes that are included in that scale
 		switch (selectedScale) {
 			case 'major':
 				indexesToSelect = [0, 2, 4, 5, 7, 9, 11, 12];

--- a/client/context/keyboard-options-context.tsx
+++ b/client/context/keyboard-options-context.tsx
@@ -2,6 +2,8 @@
 // Provides global state to the client. Manages the selection change
 // in the keyboard-settings using a selection handler. This updated state affects
 // the sounds played as well as the keys that show up in keyboard-selected.
+// Based on the selections made, the context will also provide all notes in the
+// selected octave as well as the notes belonging to the selected scale.
 // The activeNote updates whenever a key is pressed or when the play button
 // plays a series of notes. This will update the styles of the key at that note.
 
@@ -90,10 +92,7 @@ export const KeyboardOptionsProvider = ({
 	}
 	const fullNotesOctave = rearrangeNotes();
 
-	function defineScaleNotes(
-		fullNotesOctave: FullNote[],
-		selectedScale: Scale
-	): FullNote[] {
+	function defineScaleNotes(fullNotesOctave: FullNote[]): FullNote[] {
 		switch (selectedScale) {
 			case 'major':
 				const indexesToSelect = [0, 2, 4, 5, 7, 9, 11, 12];
@@ -104,7 +103,7 @@ export const KeyboardOptionsProvider = ({
 				return fullNotesOctave;
 		}
 	}
-	const selectedScaleNotes = defineScaleNotes(fullNotesOctave, selectedScale);
+	const selectedScaleNotes = defineScaleNotes(fullNotesOctave);
 
 	return (
 		<KeyboardOptionsContext.Provider

--- a/client/types/keyboard-option-types.ts
+++ b/client/types/keyboard-option-types.ts
@@ -19,6 +19,14 @@ export type OctaveNum = 1 | 2 | 3 | 4 | 5 | 6 | 7;
 
 export type Waveform = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
-export type Scale = 'chromatic' | 'major';
+export type Scale =
+	| 'chromatic'
+	| 'major'
+	| 'natural minor'
+	| 'harmonic minor'
+	| 'melodic minor'
+	| 'major pentatonic'
+	| 'minor pentatonic'
+	| 'blues';
 
 export type FullNote = `${NoteKey}${OctaveNum}`;

--- a/client/values/settingsOptions.ts
+++ b/client/values/settingsOptions.ts
@@ -6,6 +6,7 @@
 import type {
 	NoteKey,
 	OctaveNum,
+	Scale,
 	Waveform,
 } from '@/types/keyboard-option-types';
 
@@ -31,6 +32,17 @@ const octaveOptions: OctaveNum[] = Array.from(
 
 const waveformOptions: Waveform[] = ['sine', 'sawtooth', 'triangle', 'square'];
 
+const scaleOptions: Scale[] = [
+	'chromatic',
+	'major',
+	'natural minor',
+	'harmonic minor',
+	'melodic minor',
+	'major pentatonic',
+	'minor pentatonic',
+	'blues',
+];
+
 export const settingsOptions = {
 	key: {
 		options: noteOptions,
@@ -51,7 +63,7 @@ export const settingsOptions = {
 		name: 'waveform',
 	},
 	scale: {
-		options: ['chromatic', 'major'],
+		options: scaleOptions,
 		ariaLabel: 'Select a scale',
 		title: 'Scale',
 		name: 'scale',


### PR DESCRIPTION
## Description
Added more scale options to the dropdown and provided the appropriate values for defining the notes in the scale

## Steps to test / reproduce
From the home page, open the settings and change the scale. The notes that are highlighted will change depending on the scale. The notes played will also update.

## Types of changes

<!--- Put an `x` in all the boxes that apply to your changes. -->

- [ ] Fix (non-breaking change that solves an issue/bug)
- [x] New feature (non-breaking change that adds functionality)\
- [ ] Task (non-breaking change that is not a bug or feature)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

## Reminders

<!--- Put an `x` in all the boxes that apply to your changes. -->

- [x] I have tested that my code builds successfully
- [x] I have pulled the latest version of this branch's base branch (i.e. `main`)
- [x] I have updated the README or inline docs if needed
- [x] I have added a short, descriptive title to this PR

## Other comments
